### PR TITLE
add access logging for cloudtrail bucket

### DIFF
--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -8,6 +8,11 @@ data "template_file" "aws_s3_bucket_policy" {
   }
 }
 
+resource "aws_s3_bucket" "cloudtrail_log_bucket" {
+  bucket = "${var.aws_account}-${var.aws_cloudtrail_access_log_bucket}"
+  acl = "log-delivery-write"
+}
+
 resource "aws_s3_bucket" "bucket" {
   # This is to keep things consistrent and prevent conflicts across
   # environments.
@@ -21,6 +26,10 @@ resource "aws_s3_bucket" "bucket" {
   tags = {
     terraform = "true"
   }
+  logging {
+    target_bucket = "${aws_s3_bucket.cloudtrail_log_bucket.id}"
+    target_prefix = "log/"
+  }
   depends_on = ["aws_sns_topic_subscription.sqs"]
 }
 
@@ -28,4 +37,3 @@ resource "aws_s3_bucket_policy" "bucket" {
   bucket = "${aws_s3_bucket.bucket.id}"
   policy = "${data.template_file.aws_s3_bucket_policy.rendered}"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "aws_cloudtrail_name" {
   default = "ThreatStackIntegration"
 }
 
+variable "aws_cloudtrail_access_log_bucket" {
+  type = "string"
+  description = "S3 bucket to send cloudtrail access logs to"
+  default = "cloudtrail-accesslogs"
+}
+
 variable "aws_iam_role_name" {
   type = "string"
   description = "Threat Stack IAM role Name"
@@ -93,4 +99,3 @@ variable "is_multi_region_trail" {
   description = "Whether the trail is created in all regions or just the current region."
   default = true
 }
-


### PR DESCRIPTION
This addresses a config audit finding within Threat Stack, which requires that "Access Logging Is Enabled for CloudTrail Logs".  